### PR TITLE
Add toggle to show Guildname for player in tooltip

### DIFF
--- a/AzeriteUI/Components/Misc/Tooltips.lua
+++ b/AzeriteUI/Components/Misc/Tooltips.lua
@@ -73,6 +73,7 @@ local defaults = { profile = ns:Merge({
 	theme = "Classic",
 	showItemID = false,
 	showSpellID = false,
+	showGuildName = false,
 	anchor = true,
 	anchorToCursor = false,
 	hideInCombat = false,
@@ -429,10 +430,18 @@ Tooltips.OnTooltipSetUnit = function(self, tooltip, data)
 	local color = GetUnitColor(unit)
 	if (color) then
 
+<<<<<<< HEAD
 		local unitName, unitRealm = UnitName(unit)
 		local displayName = color.colorCode..unitName.."|r"
 		local gray = Colors.quest.gray.colorCode
 		local levelText
+=======
+			local unitName, unitRealm = UnitName(unit)
+			local guildName, _, _, _ = GetGuildInfo(unit)
+			local displayName = color.colorCode..unitName.."|r"
+			local gray = Colors.quest.gray.colorCode
+			local levelText
+>>>>>>> 9dea4cf (Add toggle to show Guildname for player in tooltip)
 
 		if (UnitIsPlayer(unit)) then
 			if (unitRealm and unitRealm ~= "") then
@@ -446,10 +455,23 @@ Tooltips.OnTooltipSetUnit = function(self, tooltip, data)
 			end
 		end
 
+<<<<<<< HEAD
 		if (levelText) then
 			_G.GameTooltipTextLeft1:SetText(levelText .. gray .. ": |r" .. displayName)
 		else
 			_G.GameTooltipTextLeft1:SetText(displayName)
+=======
+			if (levelText) then
+				_G.GameTooltipTextLeft1:SetText(levelText .. gray .. ": |r" .. displayName)
+			else
+				_G.GameTooltipTextLeft1:SetText(displayName)
+			end
+
+			if (self.db.profile.showGuildName and guildName) then
+          tooltip:AddLine(guildName, 1, 0.8, 0) -- Add the guild name on a new line
+      end
+
+>>>>>>> 9dea4cf (Add toggle to show Guildname for player in tooltip)
 		end
 
 	end

--- a/AzeriteUI/Options/OptionsPages/Tooltips.lua
+++ b/AzeriteUI/Options/OptionsPages/Tooltips.lua
@@ -134,6 +134,14 @@ local GenerateOptions = function()
 				set = setter,
 				get = getter
 			},
+			showGuildName = {
+				name = L["Show Guildname"],
+				desc = L["Toggle whether to add Guildname in tooltips or not."],
+				order = 23,
+				type = "toggle", width = "full",
+				set = setter,
+				get = getter
+			},
 			anchorHeader = {
 				name = L["Position"],
 				order = 29,


### PR DESCRIPTION
This PR adds a new option to the Tooltip settings, that allows to show the Guildname of a player:

![WoWScrnShot_032024_113513](https://github.com/GoldpawsStuff/AzeriteUI5/assets/110252326/7f2bf796-1f6f-4414-9b30-04abf8c4c2dc)
![Screenshot 2024-03-20 at 11 35 54](https://github.com/GoldpawsStuff/AzeriteUI5/assets/110252326/f2556d3c-dcf0-4d38-8033-9d987d639b52)

