### PR TITLE
Components: Fix Lua errors when world quests are added to objectives

### DIFF
--- a/AzeriteUI/Components/Misc/Banners.lua
+++ b/AzeriteUI/Components/Misc/Banners.lua
@@ -48,6 +48,7 @@ local banners = {
 	{ "Blizzard_MajorFactions", "MajorFactionsRenownToast", 128, 128, "TOP", 0, -160 },
 	{ "Blizzard_MajorFactions", "MajorFactionUnlockToast", 128, 128, "TOP", 0, -180 },
 	{ "Blizzard_ObjectiveTracker", "ObjectiveTrackerBonusBannerFrame", 128, 128, "TOP", 0, -170 },
+	{ "Blizzard_ObjectiveTracker", "ObjectiveTrackerTopBannerFrame", 128, 128, "TOP", 0, -170 },
 	{ "Blizzard_PVPUI", "PvPObjectiveBannerFrame", 128, 128, "TOP", 0, -180 }
 }
 


### PR DESCRIPTION
`ObjectiveTrackerBonusBannerFrame` has been renamed to `ObjectiveTrackerTopBannerFrame` in War Within. This PR adds it as a possible frame to position to ensure this happens before any animations might have occurred.

## Explanation of the Bug:

If the custom position of this frame is not set up directly (and is instead attempted during its animation flow) a Lua error is triggered in the game:

* The built-in `TopBannerManager_Show` calls `frame:PlayBanner(data)`
* This function will call `self.PopAnim:Restart();` at the very end to start the pop-in animation (e.g. when a player moves into the vicinity of a world quest)
* Once that animation finishes, `OnPopAnimFinished()` is called
* This function will trigger a slide animation to make it seem as if the banner alert is "moved" into the objective tracker
* To do this, the function first needs to get the position of the "World Quests" module within the objective tracker, which it does by calling `ObjectiveTrackerManager:GetContainerForModule(self.module); `

The observed error points out that the _return value_ of this call is a `nil` value. The most probable way this can happen is if `self.module` itself is a `nil` value, which will be the case if `OnSlideAnimFinished` was called, which in turn calls `Finish` and sets `self.module` to `nil`.

My hunch is that when AzeriteUI's `TopBannerManager_Show` function is called via the secure hook, `StopBanner` will be called prematurely, which will also lead to a call to `Finish` and thus the `module` is set to `nil` and once AzeriteUI calls `PlayBanner` again, `OnPopAnimFinished` will not have a valid `module` value to call `GetContainerForModule` with.

> [!NOTE]
> It is probable that the entire pattern (stopping the animation, relocating the banner, then starting the animation again) is currently _potentially_ broken in War Within insofar as if an animation is stopped its internal state (set up by `ObjectiveTrackerTopBannerMixin:DisplayForQuest`) is broken and not usable for a second trigger to play the animation.