### PR TITLE
Components: Fix reputation status bars for retail WoW

### DIFF
--- a/AzeriteUI/Components/ActionBars/Elements/StatusBars.lua
+++ b/AzeriteUI/Components/ActionBars/Elements/StatusBars.lua
@@ -351,7 +351,7 @@ StatusBars.UpdateBars = function(self, event, ...)
 	local bonusShown = bonus:IsShown()
 	local showButton
 
-	local name, standingID, min, max, current, factionID = GetWatchedFactionInfo and GetWatchedFactionInfo()
+	local name, standingID, min, max, current, factionID = GetWatchedFactionInfo()
 
 	if (name and not standingID) then
 		for i = 1, GetNumFactions() do

--- a/AzeriteUI/Core/Compatibility.lua
+++ b/AzeriteUI/Core/Compatibility.lua
@@ -164,3 +164,52 @@ if (tocversion >= 100205) or (tocversion >= 40400 and tocversion < 50000) then
 		end
 	end
 end
+
+-- Deprecated in 11.0.0
+if (tocversion >= 110000) then
+	for method,func in next, {
+		GetWatchedFactionInfo = function()
+			local watchedFactionData = C_Reputation.GetWatchedFactionData()
+
+			if watchedFactionData then
+				return watchedFactionData.name,
+					   watchedFactionData.reaction,
+					   watchedFactionData.currentReactionThreshold,
+					   watchedFactionData.nextReactionThreshold,
+					   watchedFactionData.currentStanding,
+					   watchedFactionData.factionID
+			else
+				return nil
+			end
+		end,
+		GetNumFactions = C_Reputation.GetNumFactions,
+		GetFactionInfo = function(index)
+			local factionData = C_Reputation.GetFactionDataByIndex(index)
+
+			if (factionData) then
+				return factionData.name,
+					   factionData.description,
+					   factionData.reaction,
+					   factionData.currentReactionThreshold,
+					   factionData.nextReactionThreshold,
+					   factionData.currentStanding,
+					   factionData.atWarWith,
+					   factionData.canToggleAtWar,
+					   factionData.isHeader,
+					   factionData.isCollapsed,
+					   factionData.isHeaderWithRep,
+					   factionData.isWatched,
+					   factionData.isChild,
+					   factionData.factionID,
+					   factionData.hasBonusRepRain,
+					   factionData.canSetInactive
+			else
+				return nil
+			end
+		end
+	} do
+		if (not _G[method]) then
+			_G[method] = func
+		end
+	end
+end


### PR DESCRIPTION
Adds compatibility shims for reputation API methods changed in The War Within:

* `GetWatchedFactionInfo -> C_Reputation.GetWatchedFactionData`
* `GetNumFactions -> C_Reputation.GetNumFactions`
* `GetFactionInfo -> C_Reputation.GetFactionDataByIndex`

With the exception of `GetNumFactions` (which returns a simple scalar integer), all new API functions return table data instead of multiple return values. This has been a theme in most recent API changes and will probably continue into the future.

An additional change in `StatusBars.lua` was necessary as `GetWatchedFactionInfo and GetWatchedFactionInfo` will **not** yield the multiple return values of `GetWatchedFactionInfo`:

The pattern `expression and expression` only yields a single return value, so `name` would be the only value ever returned by this pattern.

Only accessing `GetWatchedFactionInfo` immediately will yield all the values.