### PR TITLE
Core: Add support for Retail addon compartment

### DIFF
--- a/AzeriteUI/AzeriteUI.toc
+++ b/AzeriteUI/AzeriteUI.toc
@@ -5,6 +5,9 @@
 ## Notes: Custom user graphical interface.|n|nDesign by Daniel Troko and Lars Norberg.|nCode by Lars Norberg.|n|n|cff4488ffPayPal|r|cffffffff:|r |n|cffffffffwww.paypal.me/GoldpawsStuff|r|n|n|cff4488ffPatreon|r|cffffffff:|r |n|cffffffffwww.patreon.com/GoldpawsStuff|r
 ## Version: @project-version@
 ## Author: Daniel Troko, Lars Norberg
+## AddonCompartmentFuncOnEnter: Azerite_OnAddonCompartmentEnter
+## AddonCompartmentFuncOnLeave: Azerite_OnAddonCompartmentLeave
+## AddonCompartmentFunc: Azerite_OnAddonCompartmentClick
 
 ## X-Category: Interface Enhancements
 ## X-Curse-Project-ID: 298648

--- a/AzeriteUI/Components/Misc/Minimap.lua
+++ b/AzeriteUI/Components/Misc/Minimap.lua
@@ -512,6 +512,9 @@ end
 -- Addon Styling & Initialization
 --------------------------------------------
 MinimapMod.InitializeMBB = function(self)
+	if (self.addonCompartment) then
+		self.addonCompartment:SetParent(ns.Hider)
+	end
 
 	local button = CreateFrame("Frame", nil, Minimap)
 	button:SetFrameLevel(button:GetFrameLevel() + 10)
@@ -827,6 +830,53 @@ MinimapMod.CreateCustomElements = function(self)
 	mailFrame:SetAllPoints(mail)
 
 	self.mail = mail
+
+	-- Addon Compartment
+	if (ns.IsRetail) then
+		local addonCompartment = self.Objects.Addons
+		if (addonCompartment) then
+			local addons = CreateFrame("DropdownButton", nil, Minimap)
+			addons:SetPoint("BOTTOMRIGHT", -252, 43)
+			addons:SetSize(16, 16)
+
+			addons:SetupMenu(addonCompartment.menuGenerator)
+
+			local addonsAnchor = AnchorUtil.CreateAnchor("BOTTOMRIGHT", addons, "TOPLEFT", 0, 0)
+			addons:SetMenuAnchor(addonsAnchor)
+
+			addons:SetScript("OnEnter", function(self)
+				addons:SetAlpha(.95)
+
+				if (GameTooltip:IsForbidden()) then return end
+
+				GameTooltip_SetDefaultAnchor(GameTooltip, self)
+				GameTooltip_SetTitle(GameTooltip, ADDONS)
+				GameTooltip:Show()
+			end)
+
+			addons:SetScript("OnLeave", function(self)
+				addons:SetAlpha(.5)
+
+				if (GameTooltip:IsForbidden()) then return end
+
+				GameTooltip:Hide()
+			end)
+
+			local addonsText = addons:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
+			addonsText:SetText(addonCompartment:GetText())
+			addonsText:SetPoint("CENTER")
+			addons:SetFontString(addonsText)
+			addons.text = addonsText
+
+			hooksecurefunc(addonCompartment, "UpdateDisplay", function(self)
+				addonsText:SetText(self:GetText())
+			end)
+
+			addons:SetAlpha(.5)
+
+			self.addonCompartment = addons
+		end
+	end
 
 	local dropdown = LibDD:Create_UIDropDownMenu(ns.Prefix.."MiniMapTrackingDropDown", UIParent)
 	dropdown:SetID(1)

--- a/AzeriteUI/Core/AddonCompartment.lua
+++ b/AzeriteUI/Core/AddonCompartment.lua
@@ -1,0 +1,76 @@
+--[[
+
+    The MIT License (MIT)
+
+    Copyright (c) 2024 Patrick Heyer
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+--]]
+
+-- GLOBALS: Azerite_OnAddonCompartmentEnter, Azerite_OnAddonCompartmentLeave, Azerite_OnAddonCompartmentClick
+-- GLOBALS: GameTooltip
+
+local Addon, ns = ...
+
+if (not ns.IsRetail) then return end
+
+local AddonCompartment = ns:NewModule("AddonCompartment")
+
+local GetAddOnMetadata = _G.GetAddOnMetadata
+local title = GetAddOnMetadata(Addon, "Title");
+local icon = GetAddOnMetadata(Addon, "IconTexture");
+
+AddonCompartment.AddonCompartmentEnter = function(self, _, menuButtonFrame)
+    GameTooltip:SetOwner(menuButtonFrame, "ANCHOR_NONE")
+    GameTooltip:SetPoint("TOPRIGHT", menuButtonFrame, "BOTTOMRIGHT", 0, 0)
+
+    GameTooltip:ClearLines()
+    GameTooltip:AddDoubleLine(title, ns.Version)
+    GameTooltip_AddBlankLineToTooltip(GameTooltip)
+    GameTooltip:AddLine("Left click to open Azerite UI configuration")
+    GameTooltip:AddLine("Right click to open frame manager")
+
+    GameTooltip:Show()
+end
+
+AddonCompartment.AddonCompartmentLeave = function(self)
+    GameTooltip:Hide()
+end
+
+AddonCompartment.AddonCompartmentClick = function(self, _, button)
+    if (button == "LeftButton") then
+        if (self.options) then
+            self.options:OpenOptionsMenu()
+        end
+    elseif (button == "RightButton") then
+        if (self.framesManager) then
+            self.framesManager:ToggleMFMFrame()
+        end
+    end
+end
+
+AddonCompartment.OnEnable = function(self)
+    self.options = ns:GetModule("Options") or {}
+    self.framesManager = ns:GetModule("MovableFramesManager") or {}
+end
+
+_G[ns.Prefix .. "_OnAddonCompartmentEnter"] = function(...) AddonCompartment:AddonCompartmentEnter(...) end
+_G[ns.Prefix .. "_OnAddonCompartmentLeave"] = function(...) AddonCompartment:AddonCompartmentLeave(...) end
+_G[ns.Prefix .. "_OnAddonCompartmentClick"] = function(...) AddonCompartment:AddonCompartmentClick(...) end

--- a/AzeriteUI/Core/Core.xml
+++ b/AzeriteUI/Core/Core.xml
@@ -38,6 +38,7 @@
 	<!--<Script file="EditModePresets.lua"/>-->
 	<Script file="MovableFrameManager.lua"/>
 	<Script file="MovableFrameModulePrototype.lua"/>
+	<Script file="AddonCompartment.lua"/>
 	<Script file="FixBlizzardBugs.lua"/>
 	<Script file="FixFlavorDifferences.lua"/>
 	<Script file="ExplorerMode.lua"/>


### PR DESCRIPTION
This PR adds support for the addon compartment added in Dragonflight:

* The Retail TOC file adds the new values of the corresponding functions (alternatively this can be implemented entirely in code, ymmv.
* A new addon compartment module adds the corresponding functions to add an AzeriteUI item with a corresponding tooltip
* The menu item will open the AzeriteUI options on left-button mouse click and the movable frame manager on a right click

The compartment is also added to the minimap in Retail WoW in the same position as the MinimapButton addon. If MBB is installed, the addon compartment button is re-parented to the "Hider" frame to make space for its own implementation.