### PR TITLE
Components: Adds ping system support to target portrait

### DIFF
--- a/AzeriteUI/Components/UnitFrames/Units/Target.lua
+++ b/AzeriteUI/Components/UnitFrames/Units/Target.lua
@@ -33,6 +33,9 @@ local next = next
 local string_gsub = string.gsub
 local type = type
 local unpack = unpack
+local Mixin = _G.Mixin
+local Enum = _G.Enum
+local UnitGUID = _G.UnitGUID
 
 -- Addon API
 local Colors = ns.Colors
@@ -749,7 +752,23 @@ local style = function(self, unit, id)
 
 	self.Portrait.Bg = portraitBg
 
-	local portraitOverlayFrame = CreateFrame("Frame", nil, self)
+	local portraitOverlayFrame = nil
+	if (ns.IsRetail) then
+		portraitOverlayFrame = CreateFrame("Frame", nil, self, "PingReceiverAttributeTemplate")
+
+		Mixin(portraitOverlayFrame, PingableTypeMixin)
+
+		portraitOverlayFrame.GetContextualPingType = function(self)
+			return PingUtil:GetContextualPingTypeForUnit(self:GetTargetPingGUID())
+		end
+
+		portraitOverlayFrame.GetTargetPingGUID = function(self)
+			return UnitGUID(unit)
+		end
+	else
+		portraitOverlayFrame = CreateFrame("Frame", nil, self)
+	end
+
 	portraitOverlayFrame:SetFrameLevel(self:GetFrameLevel() - 1)
 	portraitOverlayFrame:SetAllPoints()
 


### PR DESCRIPTION
The target portrait is a large area of the target unit frame that might be intuitively used by players to ping their target.

While oUF adds this by itself to the actual unit frame, the overlay frame added by AzeriteUI will not inherit the functionality.

This change adds the PingableTypeMixin to the overlay on retail WoW, thus making it compatible with the ping system (the type and context of the ping is automatically deducted from the GUID of the unitframe's `unit` variable.