### PR TITLE
Components: Add addon memory usage tooltip to framerate widget

### DIFF
--- a/AzeriteUI/Locale/deDE.lua
+++ b/AzeriteUI/Locale/deDE.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "Aktionsleiste %d"
 L["Action Bar Settings"] = "Aktionsleisteneinstellungen"
 L["Action Bars"] = "Aktionsleisten"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "Über Aktionsleisten kann schnell auf Fähigkeiten und Gegenstände im Inventar zurückgegriffen werden. Hier könnt Ihr zusätzliche Aktionsleisten aktivieren und anpassen."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/enUS.lua
+++ b/AzeriteUI/Locale/enUS.lua
@@ -11,6 +11,7 @@ L["Action Bar %d"] = true
 L["Action Bar Settings"] = true
 L["Action Bars"] = true
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = true
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/esES.lua
+++ b/AzeriteUI/Locale/esES.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "Barra de acción %d"
 L["Action Bar Settings"] = "Configuración de la barra de acción"
 L["Action Bars"] = "Barras de acción"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "Son bancos de teclas que te permiten acceder a facultades y objetos del inventario con rapidez. Aquí podrás activar más Barras de acción y controlar su configuración."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/frFR.lua
+++ b/AzeriteUI/Locale/frFR.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "Barre d’actions %d"
 L["Action Bar Settings"] = "Paramètre de la barre d’actions"
 L["Action Bars"] = "Barres d’action"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "Les barres d'actions sont des rangées de raccourcis facilitant l'accès à vos capacités ou à vos objets. Ici, vous pouvez activer et paramétrer des barres d'actions supplémentaires."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/itIT.lua
+++ b/AzeriteUI/Locale/itIT.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "Barra delle azioni %d"
 L["Action Bar Settings"] = "Impostazioni Barra delle azioni"
 L["Action Bars"] = "Barre delle azioni"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "Le barre delle azioni permettono di accedere rapidamente alle abilità e agli oggetti dell'inventario. Qui puoi attivare le barre delle azioni aggiuntive e modificare il loro funzionamento."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/koKR.lua
+++ b/AzeriteUI/Locale/koKR.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "행동 단축바 %d"
 L["Action Bar Settings"] = "행동 단축바 설정"
 L["Action Bars"] = "행동 단축바"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "행동 단축바는 능력이나 아이템을 바로 사용할 수 있도록 단축키를 모아 놓은 것입니다. 행동 단축바를 추가하거나 작동 방식을 변경합니다."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/ptBR.lua
+++ b/AzeriteUI/Locale/ptBR.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "Barra de ações %d"
 L["Action Bar Settings"] = "Configurações da Barra de Ações"
 L["Action Bars"] = "Barras de ação"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "As Barras de Ações são bancos de atalhos que permitem ter acesso rápido a habilidades e itens do inventário. Aqui é possível ativar Barras de Ações adicionais e ajustar a configuração."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/ruRU.lua
+++ b/AzeriteUI/Locale/ruRU.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "Панель команд %d"
 L["Action Bar Settings"] = "Настройки панелей команд"
 L["Action Bars"] = "Панели команд"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "Панели команд обеспечивают быстрый доступ к способностям и предметам персонажа. Здесь вы можете включить дополнительные панели команд и настроить их."
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/zhCN.lua
+++ b/AzeriteUI/Locale/zhCN.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "动作条 %d"
 L["Action Bar Settings"] = "动作条设定"
 L["Action Bars"] = "动作条"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "动作条是一排用来放置快捷键的位置，可以使你快速使用技能和物品。你可以在这里开启额外的动作条并对它们进行设定。"
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true

--- a/AzeriteUI/Locale/zhTW.lua
+++ b/AzeriteUI/Locale/zhTW.lua
@@ -12,6 +12,7 @@ L["Action Bar %d"] = "快捷列%d"
 L["Action Bar Settings"] = "快捷列設定"
 L["Action Bars"] = "快捷列"
 L["ActionBars are banks of hotkeys that allow you to quickly access abilities and inventory items. Here you can activate additional ActionBars and control their behaviors."] = "快捷列是一個存放熱鍵的工具列，可讓你更快速地使用技能與物品欄的物品。你可以在這裡啟用額外的快捷列並控制它們的功能。"
+L["AddOn Memory Usage"] = true
 L["Alerts"] = true
 L["Always show unit names."] = true
 L["Always use Power Crystal"] = true


### PR DESCRIPTION
The default Blizzard interface displays framerate, latency, and addon memory usage in the tooltip for the main menu button in the MicroMenu.

AzeriteUI displays framerate and latency in its info widget, but has no equivalent display for addon memory usage.

This change adds a tooltip to the fps widget with that information, using similar code to Blizzard's own tooltip code.

> [!NOTE]
> One interesting detail of this implementation is that this code generates garbage memory on every tooltip update as at the very least the line with AzeriteUI's own memory usage will be updated, which in turn increases its memory usage, which will require an update of the tooltip.
>
> Thus when displaying the tooltip, AzeriteUI's own memory usage will constantly increase (but also cleaned up by garbage collection), something that Blizzard's own code does not run into when showing this tooltip.