### PR TITLE
Components: Fix displaced alerts in The War Within

### DIFF
--- a/AzeriteUI/Components/Misc/AlertFrames.lua
+++ b/AzeriteUI/Components/Misc/AlertFrames.lua
@@ -30,7 +30,7 @@ local L = LibStub("AceLocale-3.0"):GetLocale((...))
 local AlertFrames = ns:NewModule("AlertFrames", ns.MovableModulePrototype, "LibMoreEvents-1.0", "AceHook-3.0")
 
 -- GLOBALS: CreateFrame
--- GLOBALS: AlertFrame, GroupLootContainer, UIParent
+-- GLOBALS: AlertFrame, GroupLootContainer, UIParent, TalkingHeadFrame
 -- GLOBALS: UIPARENT_MANAGED_FRAME_POSITIONS
 
 -- Lua API
@@ -120,6 +120,11 @@ local AlertSubSystem_AdjustAnchorsNonAlert = function(self, relativeAlert)
 	local point, relPoint, x, y = GetPoints()
 
 	local anchorFrame = self.anchorFrame
+
+	if (anchorFrame and ns.WoW11 and anchorFrame == TalkingHeadFrame) then
+		return relativeAlert
+	end
+
 	if (anchorFrame and anchorFrame:IsShown()) then
 		anchorFrame:ClearAllPoints()
 		anchorFrame:SetPoint(point, relativeAlert, relPoint, 0, config.AlertFramesPadding * y)


### PR DESCRIPTION
Currently the Talking Head frame is managed by the Edit Mode in Retail WoW, which leads to an unfortunate visual error whenever alerts are displayed:

First the talking head frame is anchored to AzeriteUI's alert frame, before its placed to its location as set in Edit Mode. Any consecutive alert is anchored to the Talking Head frame, so when using its default position, the alerts grow downwards below the visible area.

So ignoring the Talking Head position (as its truly externally managed) and instead returning relativeAlert fixes the issue, as all consecutive alerts are correctly anchored to the alert frame again.