### PR TITLE
Components: Implement GetFrame function to War Within objective tracker

### DIFF
--- a/AzeriteUI/Components/Misc/TrackerWoW11.lua
+++ b/AzeriteUI/Components/Misc/TrackerWoW11.lua
@@ -83,6 +83,8 @@ Tracker.PrepareFrames = function(self)
 	ObjectiveTrackerFrame:SetClampedToScreen(false)
 	ObjectiveTrackerFrame:SetAlpha(.9)
 
+	self.GetFrame = function() return ObjectiveTrackerFrame end
+
 end
 
 Tracker.UpdateSettings = function(self)


### PR DESCRIPTION
Adding the GetFrame function makes the War Within tracker compatible with explorer mode and allows it to be faded out with the other UI elements.