### PR TITLE
remove 'reverse magic' detection for demon hunters

### DIFF
--- a/AzeriteUI/Libs/oUF_Plugins/oUF_PriorityDebuff.lua
+++ b/AzeriteUI/Libs/oUF_Plugins/oUF_PriorityDebuff.lua
@@ -146,12 +146,6 @@ local DispelTypesBySpec = {
 		Poison = true,
 		Disease = function() return IsUsableSpell(GetSpellInfo(374251)) end,
 		Curse = function() return IsUsableSpell(GetSpellInfo(374251)) end
-	},
-	[577] = {
-		Magic = function() return GetSpellInfo(205604) end, -- Reverse Magic
-	},
-	[581] = {
-		Magic = function() return GetSpellInfo(205604) end, -- Reverse Magic
 	}
 }
 


### PR DESCRIPTION
When using demon hunters in PVE scenarios (dungeons / raids ), errors are keeping raising.
Not very sure about the root cause, but removing these code does work.
Here's the error detail:
 ------------------------
48x ...ns/AzeriteUI/Libs/oUF_Plugins/oUF_PriorityDebuff.lua:151: attempt to call upvalue 'GetSpellInfo' (a nil value)
[string "@AzeriteUI/Libs/oUF_Plugins/oUF_PriorityDebuff.lua"]:151: in function `data'
[string "@AzeriteUI/Libs/oUF_Plugins/oUF_PriorityDebuff.lua"]:405: in function <...ns/AzeriteUI/Libs/oUF_Plugins/oUF_PriorityDebuff.lua:372>
[string "=(tail call)"]: ?

Locals:
(*temporary) = nil
(*temporary) = 205604
(*temporary) = "attempt to call upvalue 'GetSpellInfo' (a nil value)"
GetSpellInfo = nil